### PR TITLE
[BUGFIX] lazyLoading must only be used if loading is not set

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -286,7 +286,7 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\ImageViewHelper
                 if (!empty($this->arguments['class'])) {
                     $this->tag->addAttribute('class', $this->arguments['class']);
                 }
-                if (!empty($this->settings['lazyLoading'])) {
+                if (!empty($this->settings['lazyLoading']) && !$this->hasArgument('loading')) {
                     $this->tag->addAttribute('loading', $this->settings['lazyLoading']);
                 }
 


### PR DESCRIPTION
If the attribute `loading` is used, it must not be overloaded by the TS setting. By checking the arguments it is now possible to change the loading behaviour for one usage.