### PR TITLE
[BUGFIX] Avoid double encoding in srcset attribute

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -152,7 +152,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
                 $sourceOutputs[] = $tag->render();
 
                 // Build additional source with type webp if attribute addWebp is set and previously build tag is not type of webp already.
-                $type = $tag->getAttribute('type');
+                $type = htmlspecialchars_decode($tag->getAttribute('type') ?? '');
                 if ($type !== 'image/webp' && $this->pictureConfiguration->webpShouldBeAdded()) {
                     $tag = $this->addWebpImage($sourceConfiguration);
                     array_unshift($sourceOutputs, $tag->render());
@@ -346,7 +346,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         // Process additional retina images. Tag value can be gathered for source tags from srcset value as there it
         // was to be set already because adding retina is not mandatory.
         if ($tag->hasAttribute('srcset')) {
-            $tagValue = $tag->getAttribute('srcset');
+            $tagValue = htmlspecialchars_decode($tag->getAttribute('srcset') ?? '');
             $tag->removeAttribute('srcset');
         } else {
             $tagValue = $imageUriRegular;

--- a/Tests/Functional/ViewHelpers/Fixtures/ImageWithSourcesAndRetina.html
+++ b/Tests/Functional/ViewHelpers/Fixtures/ImageWithSourcesAndRetina.html
@@ -1,0 +1,9 @@
+<html
+	xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	xmlns:i="http://typo3.org/ns/B13/Picture/ViewHelpers"
+	data-namespace-typo3-fluid="true"
+>
+<i:image src="1" width="150c" height="150c"
+				 useRetina="1"
+				 sources="{md: {width: '1680c', height: '1000c'}}" />
+</html>

--- a/Tests/Functional/ViewHelpers/ImageViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ImageViewHelperTest.php
@@ -49,6 +49,26 @@ class ImageViewHelperTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function imageWithSourcesAndRetina(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/storage_with_file.csv');
+        $template = __DIR__ . '/Fixtures/ImageWithSourcesAndRetina.html';
+        $view = GeneralUtility::makeInstance(StandaloneView::class);
+        $view->setTemplatePathAndFilename($template);
+        $content = $view->render();
+        $this->assertProcessedFileExists(150, 150);
+        $this->assertProcessedFileExists(300, 300);
+        $this->assertProcessedFileExists(1680, 1000);
+        $this->assertProcessedFileExists(3360, 2000);
+        self::assertTrue(str_starts_with(trim($content), '<picture><source srcset='));
+        self::assertTrue(str_contains(trim($content), '<img src='));
+        self::assertTrue(!str_contains(trim($content), 'eID=dumpFile&amp;amp;'));
+        self::assertTrue(str_contains(trim($content), 'eID=dumpFile&amp;t='));
+    }
+
+    /**
+     * @test
+     */
     public function simpleImage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/storage_with_file.csv');


### PR DESCRIPTION
The fluid TagBuilder method setAttribute() applies htmlspecialchars to the internally stored value.
That means the value retrieved via getAttribute needs to be decoded in order to be reusable as-is.

This fixes useRetina="1" configs with eID=dumpFile URLs where ampersands would otherwise be doule encoded.