### PR TITLE
[TASK] Add picture element for SVGs IF pictureClass is set

### DIFF
--- a/Classes/Domain/Model/PictureConfiguration.php
+++ b/Classes/Domain/Model/PictureConfiguration.php
@@ -105,7 +105,7 @@ class PictureConfiguration
 
     public function pictureTagShouldBeAdded(): bool
     {
-        return $this->addWebp || $this->addSources;
+        return $this->addWebp || $this->addSources || !empty($this->arguments['pictureClass']);
     }
 
     protected function breakPointsShouldBeAdded(): bool
@@ -135,7 +135,7 @@ class PictureConfiguration
 
     public function webpShouldBeAddedAfterSrcset(): bool
     {
-        return $this->addWebp || $this->addSources || !empty($this->arguments['pictureClass']);
+        return $this->addWebp || $this->addSources;
     }
 
     public function webpShouldBeAdded(): bool

--- a/Classes/Domain/Model/PictureConfiguration.php
+++ b/Classes/Domain/Model/PictureConfiguration.php
@@ -135,7 +135,7 @@ class PictureConfiguration
 
     public function webpShouldBeAddedAfterSrcset(): bool
     {
-        return $this->addWebp && $this->addSources;
+        return $this->addWebp || $this->addSources || !empty($this->arguments['pictureClass']);
     }
 
     public function webpShouldBeAdded(): bool

--- a/Classes/Domain/Model/PictureConfiguration.php
+++ b/Classes/Domain/Model/PictureConfiguration.php
@@ -28,6 +28,7 @@ class PictureConfiguration
     protected bool $addLazyLoading = false;
     protected string $lazyLoading = '';
     protected array $arguments;
+    protected ?string $pictureClass = null;
 
     public function __construct(array $arguments, array $typoScriptSettings, FileInterface $image)
     {
@@ -53,6 +54,19 @@ class PictureConfiguration
                 $this->lazyLoading = (string)$typoScriptSettings['lazyLoading'];
             }
         }
+        if (isset($arguments['pictureClass'])) {
+            $this->pictureClass = $arguments['pictureClass'];
+        }
+    }
+
+    public function getPictureClass(): ?string
+    {
+        return $this->pictureClass;
+    }
+
+    public function hasPictureClass(): bool
+    {
+        return $this->pictureClass !== null;
     }
 
     public function getSourceConfiguration(): array
@@ -105,7 +119,7 @@ class PictureConfiguration
 
     public function pictureTagShouldBeAdded(): bool
     {
-        return $this->addWebp || $this->addSources || !empty($this->arguments['pictureClass']);
+        return $this->addWebp || $this->addSources || $this->hasPictureClass();
     }
 
     protected function breakPointsShouldBeAdded(): bool
@@ -135,7 +149,7 @@ class PictureConfiguration
 
     public function webpShouldBeAddedAfterSrcset(): bool
     {
-        return $this->addWebp || $this->addSources;
+        return $this->addWebp && $this->addSources;
     }
 
     public function webpShouldBeAdded(): bool

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -409,8 +409,8 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
      */
     protected function wrapWithPictureElement(array $output): array
     {
-        if ($this->arguments['pictureClass'] ?? false) {
-            array_unshift($output, '<picture class="' . $this->arguments['pictureClass'] . '">');
+        if ($this->pictureConfiguration->hasPictureClass()) {
+            array_unshift($output, '<picture class="' . $this->pictureConfiguration->getPictureClass() . '">');
         } else {
             array_unshift($output, '<picture>');
         }

--- a/Tests/Functional/Frontend/Fixtures/Templates/ImageWithPictureClass.html
+++ b/Tests/Functional/Frontend/Fixtures/Templates/ImageWithPictureClass.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:i="http://typo3.org/ns/B13/Picture/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+<f:spaceless>
+  <i:image src="EXT:picture/Resources/Public/Icons/Extension.svg" pictureClass="my-class"/>
+</f:spaceless>

--- a/Tests/Functional/Frontend/Fixtures/image_with_picture_class.csv
+++ b/Tests/Functional/Frontend/Fixtures/image_with_picture_class.csv
@@ -1,0 +1,12 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"root","/"
+"sys_template"
+,"uid","pid","root","constants","config"
+,1,1,1,styles.content.image.lazyLoading=lazy,"@import 'EXT:picture/Configuration/TypoScript/test.typoscript'
+page = PAGE
+page.config.disableAllHeaderCode = 1
+page.10 = FLUIDTEMPLATE
+page.10.templateRootPaths.10 = EXT:picture/Tests/Functional/Frontend/Fixtures/Templates
+page.10.templateName = ImageWithPictureClass.html
+"

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -202,6 +202,18 @@ width="400" height="200" loading="lazy" />';
         self::assertStringContainsString($this->anonymouseProcessdImage($expected), $this->anonymouseProcessdImage($body));
     }
 
+    /**
+     * @test
+     */
+    public function imageWithPictureClassRenderPictureTag(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/image_with_picture_class.csv');
+        $response = $this->executeFrontendRequestWrapper(new InternalRequest('http://localhost/'));
+        $body = (string)$response->getBody();
+        $expected = '<picture class="my-class"><img src="/typo3conf/ext/picture/Resources/Public/Icons/Extension.svg" width="256" height="256" alt="" /></picture>';
+        self::assertStringContainsString($expected, $body);
+    }
+
     protected function anonymouseProcessdImage(string $content): string
     {
         return preg_replace('/Picture_[0-9a-z]+\./', 'Picture_xxx.', $content);


### PR DESCRIPTION
If the image to process is of type SVG, the extension does not create breakpoint variants, and just renders an IMG-tag. This can lead to unexpected behaviour if the HTML/CSS is expecting a <picture>-Element with a specific class. This change adds the picture element IF a pictureClass is set.

Related: #43