### PR TITLE
[BUGFIX] prevent overriding image class variable

### DIFF
--- a/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -33,7 +33,6 @@ class ImageViewHelperTest extends UnitTestCase
         $cropVariantCollection->expects(self::once())->method('getCropArea')->with('foo');
         $imageViewHelper->expects(self::once())->method('getCropVariantCollection')->willReturn($cropVariantCollection);
         $imageViewHelper->expects(self::never())->method('getImageCropVariant');
-        $imageViewHelper->_set('image', $image);
         $configuration = [
             'width' => null,
             'height' => null,
@@ -43,7 +42,7 @@ class ImageViewHelperTest extends UnitTestCase
             'maxHeight' => null,
             'cropVariant' => 'foo',
         ];
-        $imageViewHelper->_call('getProcessingInstructions', $configuration);
+        $imageViewHelper->_call('getProcessingInstructions', $configuration, $image);
     }
 
     /**
@@ -60,7 +59,6 @@ class ImageViewHelperTest extends UnitTestCase
         $cropVariantCollection->expects(self::once())->method('getCropArea')->with('bar');
         $imageViewHelper->expects(self::once())->method('getCropVariantCollection')->willReturn($cropVariantCollection);
         $imageViewHelper->expects(self::once())->method('getImageCropVariant')->willReturn('bar');
-        $imageViewHelper->_set('image', $image);
         $configuration = [
             'width' => null,
             'height' => null,
@@ -69,7 +67,7 @@ class ImageViewHelperTest extends UnitTestCase
             'maxWidth' => null,
             'maxHeight' => null,
         ];
-        $imageViewHelper->_call('getProcessingInstructions', $configuration);
+        $imageViewHelper->_call('getProcessingInstructions', $configuration, $image);
     }
 
     /**


### PR DESCRIPTION
This PR removes the image class variable, because it was overriden in incomprehensible ways.
Instead of using the image class variable in almost any method the currently used image FileInstance is passed as method argument