### PR TITLE
[FEATURE] Add onlyWebp option

### DIFF
--- a/Classes/Domain/Model/PictureConfiguration.php
+++ b/Classes/Domain/Model/PictureConfiguration.php
@@ -20,6 +20,7 @@ class PictureConfiguration
     // 2x is default. Use multiple if retina is set in TypoScript settings.
     protected array $retinaSettings = [2 => '2x'];
     protected bool $addWebp = false;
+    protected bool $onlyWebp = false;
     protected bool $lossless = false;
     protected bool $addBreakpoints = false;
     protected array $breakpoints = [];
@@ -36,6 +37,7 @@ class PictureConfiguration
         $fileExtension = $arguments['fileExtension'] ?? $image->getExtension();
         if ($image->getExtension() !== 'svg') {
             $this->addWebp = (bool)($fileExtension === 'webp' ? false : ($arguments['addWebp'] ?? $typoScriptSettings['addWebp'] ?? false));
+            $this->onlyWebp = (bool)($fileExtension === 'webp' ? false : ($arguments['onlyWebp'] ?? $typoScriptSettings['onlyWebp'] ?? false));
             $this->useRetina = (bool)($arguments['useRetina'] ?? $typoScriptSettings['useRetina'] ?? false);
             if (isset($typoScriptSettings['retina.'])) {
                 $this->retinaSettings = $typoScriptSettings['retina.'];
@@ -159,5 +161,10 @@ class PictureConfiguration
     public function webpShouldBeAdded(): bool
     {
         return $this->addWebp;
+    }
+
+    public function webpShouldBeAddedOnly(): bool
+    {
+        return $this->onlyWebp;
     }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -2,6 +2,9 @@ plugin.tx_picture {
   # Default for adding of images as webp.
   addWebp = 0
 
+  # Default for render images as webp only.
+  onlyWebp = 0
+
   # Default for adding retina images.
   useRetina = 0
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See `EXT:picture/Configuration/TypoScript/setup.typoscript` for possible configu
 | TypoScript Configuration option | Description |
 |---------------------------------|-------------|
 | addWebp | Add webp alternative image files as sources. <br>_default: 0_ |
+| onlyWebp | Enable only images in webp format and for all size variants. <br>_default: 0_ |
 | useRetina | Add retina (2x) version of all images as sizes variants. <br>_default: 0_ |
 | lossless | Enable lossless compression for webp images. <br>_default: 0_ |
 | retina | Use custom or multiple multipliers for calculating retina image variants. <br>_default: <br>retina.2 = 2x<br>Only works in combination with `useRetina = 1` |
@@ -59,6 +60,9 @@ attribute `srcset` is extended by a 2x retina version of the image.
 Adds rendering of additional images in webp format. If it is specified without a given sources attribute, it renders a
 picture tag instead of a single img tag in order to maintain a browser fallback. If it is specified together with
 `sources` it adds an additional `source` tag above any `source` tag rendered by a given `sources` element.
+
+### onlyWebp
+Enable only images in webp format and for all size variants.
 
 ### lossless
 Enable lossless compression for webp images. If you find your webp images lacking in quality compared to jpg/png images, enable

--- a/Resources/Private/Templates/Test.html
+++ b/Resources/Private/Templates/Test.html
@@ -70,10 +70,10 @@
 <h3>Simple Image with onlyWebp option</h3>
 
 <f:variable name="html">
-	<i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width with addWebp option" />
+	<i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width onlyWebp option" />
 </f:variable>
 <f:variable name="fluid">
-	&lt;i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width with addWebp option" /&gt;
+	&lt;i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width onlyWebp option" /&gt;
 </f:variable>
 
 <f:render

--- a/Resources/Private/Templates/Test.html
+++ b/Resources/Private/Templates/Test.html
@@ -70,10 +70,10 @@
 <h3>Simple Image with onlyWebp option</h3>
 
 <f:variable name="html">
-	<i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" addWebp="1" onlyWebp="1" alt="Testimage 400px width with addWebp option" />
+	<i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width with addWebp option" />
 </f:variable>
 <f:variable name="fluid">
-	&lt;i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" addWebp="1" onlyWebp="1" alt="Testimage 400px width with addWebp option" /&gt;
+	&lt;i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" onlyWebp="1" alt="Testimage 400px width with addWebp option" /&gt;
 </f:variable>
 
 <f:render

--- a/Resources/Private/Templates/Test.html
+++ b/Resources/Private/Templates/Test.html
@@ -67,6 +67,20 @@
 		arguments="{html: html, fluid: fluid}"
 />
 
+<h3>Simple Image with onlyWebp option</h3>
+
+<f:variable name="html">
+	<i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" addWebp="1" onlyWebp="1" alt="Testimage 400px width with addWebp option" />
+</f:variable>
+<f:variable name="fluid">
+	&lt;i:image src="EXT:picture/Resources/Public/Test/Picture.png" width="400" addWebp="1" onlyWebp="1" alt="Testimage 400px width with addWebp option" /&gt;
+</f:variable>
+
+<f:render
+		section="Element"
+		arguments="{html: html, fluid: fluid}"
+/>
+
 <h3>Simple Image with Retina and addWebp option</h3>
 
 <f:variable name="html">

--- a/Tests/Functional/Frontend/Fixtures/Templates/SimpleImageWithOnlyWebpOption.html
+++ b/Tests/Functional/Frontend/Fixtures/Templates/SimpleImageWithOnlyWebpOption.html
@@ -1,0 +1,8 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:i="http://typo3.org/ns/B13/Picture/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+<f:spaceless>
+  <i:image src="EXT:picture/Resources/Public/Test/Picture.png" onlyWebp="1" width="400" alt="Testimage 400px width" />
+</f:spaceless>

--- a/Tests/Functional/Frontend/Fixtures/simple_image_with_only_webp_option.csv
+++ b/Tests/Functional/Frontend/Fixtures/simple_image_with_only_webp_option.csv
@@ -1,0 +1,12 @@
+"pages"
+,"uid","pid","title","slug"
+,1,0,"root","/"
+"sys_template"
+,"uid","pid","root","constants","config"
+,1,1,1,styles.content.image.lazyLoading=lazy,"@import 'EXT:picture/Configuration/TypoScript/test.typoscript'
+page = PAGE
+page.config.disableAllHeaderCode = 1
+page.10 = FLUIDTEMPLATE
+page.10.templateRootPaths.10 = EXT:picture/Tests/Functional/Frontend/Fixtures/Templates
+page.10.templateName = SimpleImageWithOnlyWebpOption.html
+"

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -51,7 +51,7 @@ class TagRenderingTest extends FunctionalTestCase
     public function simpleImageWithOnlyWebp(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/simple_image_with_only_webp_option.csv');
-        $response = $this->executeFrontendRequestWrapper(new InternalRequest('http://localhost/'));
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
         $body = (string)$response->getBody();
         $expected = '<img alt="Testimage 400px width" src="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp" width="400" height="200" loading="lazy" />';
         self::assertStringContainsString($this->anonymouseProcessdImage($expected), $this->anonymouseProcessdImage($body));

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -48,6 +48,18 @@ class TagRenderingTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function simpleImageWithOnlyWebp(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/simple_image_with_only_webp_option.csv');
+        $response = $this->executeFrontendRequestWrapper(new InternalRequest('http://localhost/'));
+        $body = (string)$response->getBody();
+        $expected = '<img alt="Testimage 400px width" src="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp" width="400" height="200" loading="lazy" />';
+        self::assertStringContainsString($this->anonymouseProcessdImage($expected), $this->anonymouseProcessdImage($body));
+    }
+
+    /**
+     * @test
+     */
     public function simpleImageWithRetinaOption(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/simple_image_with_retina_option.csv');


### PR DESCRIPTION
This feature adds the 'onlyWeb' option so that the images are only rendered in .webp format. Unlike using the 'fileExtension' option, SVG files are not modified.