### PR TITLE
[TASK] Only render a picture tag if needed

### DIFF
--- a/Classes/Domain/Model/PictureConfiguration.php
+++ b/Classes/Domain/Model/PictureConfiguration.php
@@ -125,7 +125,7 @@ class PictureConfiguration
 
     public function pictureTagShouldBeAdded(): bool
     {
-        return $this->addWebp || $this->addSources || $this->hasPictureClass();
+        return ($this->addWebp && !$this->onlyWebp) || $this->addSources || $this->hasPictureClass();
     }
 
     protected function breakPointsShouldBeAdded(): bool


### PR DESCRIPTION
- if there is just one image in webp format, only render an `img`-Tag
- If `pictureClass` attribute is set, always render a `picture`-Tag, even if it contains only a single `img`-Tag