### PR TITLE
[TASK] Add image type value to source tags

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -324,7 +324,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
                     $tag->addAttribute('type', $configuration['type']);
                 }
                 // add a type value if there potentially is more than one source with the same media/sizes value.
-                if ((!empty($configuration['media']) || !empty($configuration['sizes'])) && empty($configuration['type'])) {
+                if (empty($configuration['media']) && empty($configuration['type'])) {
                     $path_info = pathinfo($imageUri);
                     $tag->addAttribute('type', 'image/' . $path_info['extension']);
                 }

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -323,6 +323,11 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
                 if (!empty($configuration['type'])) {
                     $tag->addAttribute('type', $configuration['type']);
                 }
+                // add a type value if there potentially is more than one source with the same media/sizes value.
+                if ((!empty($configuration['media']) || !empty($configuration['sizes'])) && empty($configuration['type'])) {
+                    $path_info = pathinfo($imageUri);
+                    $tag->addAttribute('type', 'image/' . $path_info['extension']);
+                }
         }
 
         if ($this->pictureConfiguration->retinaShouldBeUsed()) {

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -325,8 +325,7 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
                 }
                 // add a type value if there potentially is more than one source with the same media/sizes value.
                 if (empty($configuration['media']) && empty($configuration['type'])) {
-                    $path_info = pathinfo($imageUri);
-                    $tag->addAttribute('type', 'image/' . $path_info['extension']);
+                    $tag->addAttribute('type', $processedImage->getOriginalFile()->getMimeType());
                 }
         }
 

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -102,7 +102,7 @@ srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp
         $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
         $body = (string)$response->getBody();
         $expected = '<picture>
-<source type="image/webp" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp, /typo3temp/assets/_processed_/a/2/csm_Picture_089357224d.webp 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_d356d2dde1.webp 3x" type="image/webp" />
+<source type="image/webp" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp, /typo3temp/assets/_processed_/a/2/csm_Picture_089357224d.webp 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_d356d2dde1.webp 3x" />
 <img alt="Testimage 400px width with retina and addWebp option " src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp/assets/_processed_/a/2/csm_Picture_13dd378eeb.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_3c8b5cfedf.png 3x" />
 </picture>';
         $expected = implode('', GeneralUtility::trimExplode("\n", $expected));
@@ -187,7 +187,7 @@ width="400" height="200" loading="lazy" />';
         $body = (string)$response->getBody();
         $expected = '<picture class="myPictureClass">
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_80498eb4cf.webp 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_6546fe1853.webp 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_fffe3df9da.webp 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_0a9265a906.webp 2000w" media="(min-width: 1024px)" sizes="100vh" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_39487edcc6.png 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_86fac4fe8a.png 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_a1c0b8cf78.png 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_fc98b213ea.png 2000w" media="(min-width: 1024px)" sizes="100vh" type="image/png" />
+<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_39487edcc6.png 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_86fac4fe8a.png 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_a1c0b8cf78.png 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_fc98b213ea.png 2000w" media="(min-width: 1024px)" sizes="100vh" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_79ce5f6e5c.webp 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_955087c064.webp 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_881ba9c90f.webp 400w" sizes="100vh" type="image/webp" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_724dd3b269.png 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_6cab563075.png 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_703de20dda.png 400w" sizes="100vh" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp" type="image/webp" />

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -251,7 +251,7 @@ width="400" height="200" loading="lazy" />';
         $body = (string)$response->getBody();
         $expected = '<picture class="myPictureClass">
 <source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_4b5b9dd7fe.webp" media="(min-width: 1024px)" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_b2b773d76f.png" media="(min-width: 1024px)" type="image/png" />
+<source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_b2b773d76f.png" media="(min-width: 1024px)" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_21770d9a15.webp" type="image/webp" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_0d0101f0a6.png" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_21770d9a15.webp" type="image/webp" />

--- a/Tests/Functional/Frontend/TagRenderingTest.php
+++ b/Tests/Functional/Frontend/TagRenderingTest.php
@@ -102,7 +102,7 @@ srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp
         $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
         $body = (string)$response->getBody();
         $expected = '<picture>
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp, /typo3temp/assets/_processed_/a/2/csm_Picture_089357224d.webp 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_d356d2dde1.webp 3x" type="image/webp" />
+<source type="image/webp" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp, /typo3temp/assets/_processed_/a/2/csm_Picture_089357224d.webp 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_d356d2dde1.webp 3x" type="image/webp" />
 <img alt="Testimage 400px width with retina and addWebp option " src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp/assets/_processed_/a/2/csm_Picture_13dd378eeb.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_3c8b5cfedf.png 3x" />
 </picture>';
         $expected = implode('', GeneralUtility::trimExplode("\n", $expected));
@@ -119,7 +119,7 @@ srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp
         $body = (string)$response->getBody();
         $expected = ' <picture>
  <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_30b88604ff.png" media="(min-width: 1024px)" />
- <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" />
+ <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" type="image/png" />
  <img alt="Testimage with 400px image size, 800px image size for screens &gt; 1024px" src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" />
  </picture> ';
         $expected = implode('', GeneralUtility::trimExplode("\n", $expected));
@@ -136,7 +136,7 @@ srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp
         $body = (string)$response->getBody();
         $expected = '<picture>
 <source media="(min-width: 1024px)" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_30b88604ff.png, /typo3temp/assets/_processed_/a/2/csm_Picture_9939a0a20d.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_367bb79630.png 3x" />
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp/assets/_processed_/a/2/csm_Picture_13dd378eeb.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_3c8b5cfedf.png 3x" />
+<source type="image/png" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp/assets/_processed_/a/2/csm_Picture_13dd378eeb.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_3c8b5cfedf.png 3x" />
 <img alt="Testimage with 400px image size, 800px image size for screens &gt; 1024px, with retina" src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp/assets/_processed_/a/2/csm_Picture_13dd378eeb.png 2x, /typo3temp/assets/_processed_/a/2/csm_Picture_3c8b5cfedf.png 3x" />
 </picture>';
         $expected = implode('', GeneralUtility::trimExplode("\n", $expected));
@@ -152,7 +152,7 @@ srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png, /typo3temp
         $response = $this->executeFrontendSubRequest(new InternalRequest('http://localhost/'));
         $body = (string)$response->getBody();
         $expected = '<picture>
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_724dd3b269.png 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_6cab563075.png 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_703de20dda.png 400w" sizes="100vh" />
+<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_724dd3b269.png 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_6cab563075.png 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_703de20dda.png 400w" sizes="100vh" type="image/png" />
 <img alt="Testimage with 400px image size, with multiple images as a srcset, including webp image format with fallback" src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" />
 </picture>';
         $expected = implode('', GeneralUtility::trimExplode("\n", $expected));
@@ -187,9 +187,9 @@ width="400" height="200" loading="lazy" />';
         $body = (string)$response->getBody();
         $expected = '<picture class="myPictureClass">
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_80498eb4cf.webp 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_6546fe1853.webp 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_fffe3df9da.webp 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_0a9265a906.webp 2000w" media="(min-width: 1024px)" sizes="100vh" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_39487edcc6.png 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_86fac4fe8a.png 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_a1c0b8cf78.png 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_fc98b213ea.png 2000w" media="(min-width: 1024px)" sizes="100vh" />
+<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_39487edcc6.png 800w, /typo3temp/assets/_processed_/a/2/csm_Picture_86fac4fe8a.png 1200w, /typo3temp/assets/_processed_/a/2/csm_Picture_a1c0b8cf78.png 1600w, /typo3temp/assets/_processed_/a/2/csm_Picture_fc98b213ea.png 2000w" media="(min-width: 1024px)" sizes="100vh" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_79ce5f6e5c.webp 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_955087c064.webp 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_881ba9c90f.webp 400w" sizes="100vh" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_724dd3b269.png 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_6cab563075.png 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_703de20dda.png 400w" sizes="100vh" />
+<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_724dd3b269.png 310w, /typo3temp/assets/_processed_/a/2/csm_Picture_6cab563075.png 345w, /typo3temp/assets/_processed_/a/2/csm_Picture_703de20dda.png 400w" sizes="100vh" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_cfb567934c.webp" type="image/webp" />
 <img alt="Testimage with 400px image size, 800px image size for screens &gt; 1024px, with multiple images as a srcset, including webp image format with fallback" src="/typo3temp/assets/_processed_/a/2/csm_Picture_23f7889ff5.png" width="400" height="200" loading="lazy" />
 </picture>';
@@ -251,9 +251,9 @@ width="400" height="200" loading="lazy" />';
         $body = (string)$response->getBody();
         $expected = '<picture class="myPictureClass">
 <source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_4b5b9dd7fe.webp" media="(min-width: 1024px)" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_b2b773d76f.png" media="(min-width: 1024px)" />
+<source srcset="/typo3temp/assets/_processed_/a/1/csm_Picture_alt_b2b773d76f.png" media="(min-width: 1024px)" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_21770d9a15.webp" type="image/webp" />
-<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_0d0101f0a6.png" />
+<source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_0d0101f0a6.png" type="image/png" />
 <source srcset="/typo3temp/assets/_processed_/a/2/csm_Picture_21770d9a15.webp" type="image/webp" />
 <img alt="Testimage with 400px image size, 800px image size with rotated image for screens &gt; 1024px, with webP option" src="/typo3temp/assets/_processed_/a/2/csm_Picture_0d0101f0a6.png" width="400" height="200" loading="lazy" />
 </picture>';

--- a/Tests/Functional/ViewHelpers/ImageViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ImageViewHelperTest.php
@@ -61,7 +61,7 @@ class ImageViewHelperTest extends FunctionalTestCase
         $this->assertProcessedFileExists(300, 300);
         $this->assertProcessedFileExists(1680, 1000);
         $this->assertProcessedFileExists(3360, 2000);
-        self::assertTrue(str_starts_with(trim($content), '<picture><source srcset='));
+        self::assertTrue(str_starts_with(trim($content), '<picture><source type="image/png" srcset='));
         self::assertTrue(str_contains(trim($content), '<img src='));
         self::assertTrue(!str_contains(trim($content), 'eID=dumpFile&amp;amp;'));
         self::assertTrue(str_contains(trim($content), 'eID=dumpFile&amp;t='));


### PR DESCRIPTION
This mitigates validation errors like 

"Error: A source element that has a following sibling source element or img element with a srcset attribute must have a media attribute and/or type attribute."