### PR TITLE
Make frontend.typoscript settings optional

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -501,7 +501,9 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
         }
         /** @var FrontendTypoScript $typoScript */
         $typoScript = $request->getAttribute('frontend.typoscript');
-        $setup = $typoScript->getSetupArray();
+        if ($typoScript !== null) {
+            $setup = $typoScript->getSetupArray();
+        }
         $settings = $setup['plugin.']['tx_picture.'] ?? [];
         return $settings;
     }


### PR DESCRIPTION
Allow the image view helper to be used in backend context.
Fixes #83